### PR TITLE
Enhance OSCORE with PSA key support

### DIFF
--- a/inc/common/crypto_wrapper.h
+++ b/inc/common/crypto_wrapper.h
@@ -39,6 +39,71 @@ enum err aead(enum aes_operation op, const struct byte_array *in,
 	      const struct byte_array *aad, struct byte_array *out,
 	      struct byte_array *tag);
 
+#ifdef MBEDTLS
+#include <psa/crypto.h>
+
+/**
+ * @brief			AEAD using an already-resident PSA key.
+ *
+ * Identical to aead() except the key is identified by a PSA key id and is
+ * neither imported nor destroyed here. This lets OSCORE use opaque/derived
+ * keys whose bytes never enter the non-secure domain. MBEDTLS builds only.
+ *
+ * @param op			Operation to be executed (ENCRYPT or DECRYPT).
+ * @param[in] in		Input message.
+ * @param key_id		PSA key id of the AEAD key to use.
+ * @param[in] nonce		The nonce.
+ * @param[in] aad		Additional authenticated data.
+ * @param[out] out		The cipher text / plaintext.
+ * @param[in,out] tag		The authentication tag.
+ * @return			Ok or error code.
+ */
+enum err aead_with_key_id(enum aes_operation op, const struct byte_array *in,
+			  psa_key_id_t key_id, struct byte_array *nonce,
+			  const struct byte_array *aad, struct byte_array *out,
+			  struct byte_array *tag);
+
+/**
+ * @brief			Derives an OSCORE AEAD (Sender/Recipient) key.
+ *
+ * Runs HKDF-SHA-256 with the master secret as the secret input and returns the
+ * result as a volatile PSA key handle. The key material is created directly
+ * inside the PSA/secure domain and is never copied to the non-secure domain.
+ * MBEDTLS builds only.
+ *
+ * @param master_secret_id	PSA derive key (PSA_KEY_TYPE_DERIVE) holding the
+ *				OSCORE master secret (HKDF secret input).
+ * @param[in] salt		OSCORE master salt (HKDF salt). May be empty.
+ * @param[in] info		OSCORE HKDF info (CBOR-encoded).
+ * @param bits			Derived key size in bits (128 for AES-CCM-16-64-128).
+ * @param aead_alg		PSA AEAD algorithm the derived key may be used with.
+ * @param[out] out_key_id	Receives the volatile derived-key handle.
+ * @return			Ok or error code.
+ */
+enum err oscore_derive_aead_key(psa_key_id_t master_secret_id,
+				const struct byte_array *salt,
+				const struct byte_array *info, size_t bits,
+				psa_algorithm_t aead_alg,
+				psa_key_id_t *out_key_id);
+
+/**
+ * @brief			Derives the OSCORE Common IV into plain bytes.
+ *
+ * Same HKDF-SHA-256 derivation as oscore_derive_aead_key() but outputs raw
+ * bytes; the Common IV is public so byte output is intentional. MBEDTLS only.
+ *
+ * @param master_secret_id	PSA derive key holding the OSCORE master secret.
+ * @param[in] salt		OSCORE master salt (HKDF salt). May be empty.
+ * @param[in] info		OSCORE HKDF info (CBOR-encoded).
+ * @param[out] out		Receives the derived bytes; out->len produced.
+ * @return			Ok or error code.
+ */
+enum err oscore_derive_iv_bytes(psa_key_id_t master_secret_id,
+				const struct byte_array *salt,
+				const struct byte_array *info,
+				struct byte_array *out);
+#endif /* MBEDTLS */
+
 /**
  * @brief			Derives ECDH shared secret.
  * 

--- a/inc/common/oscore_edhoc_error.h
+++ b/inc/common/oscore_edhoc_error.h
@@ -13,6 +13,18 @@
 #define ERROR_H
 #include "print_util.h"
 
+/* The OSCORE security context holds key material as opaque PSA key handles
+ * (instead of raw byte arrays) when built against the PSA / Mbed TLS backend.
+ * This changes the layout of structs SHARED between the library and the
+ * application (oscore_init_params, struct context), so both translation units
+ * must agree. The library is compiled with MBEDTLS defined; application code
+ * that includes these public headers inside a Zephyr/NCS build does not see
+ * MBEDTLS but does see CONFIG_UOSCORE / CONFIG_UEDHOC (via autoconf.h).
+ * Deriving the switch from either keeps app and library layouts in sync. */
+#if defined(MBEDTLS) || defined(CONFIG_UOSCORE) || defined(CONFIG_UEDHOC)
+#define OSCORE_PSA_OPAQUE_KEYS 1
+#endif
+
 /* All possible errors that EDHOC and OSCORE can have */
 enum err {
 	/*common errors*/

--- a/inc/oscore.h
+++ b/inc/oscore.h
@@ -66,8 +66,19 @@
  * small set of input parameters.
  */
 struct oscore_init_params {
-	/*master_secret must be provided. Currently 16 byte secrets are supported*/
+	/*master_secret must be provided. Currently 16 byte secrets are supported.
+	  On MBEDTLS builds it may be left empty if master_secret_id is set.*/
 	const struct byte_array master_secret;
+#ifdef OSCORE_PSA_OPAQUE_KEYS
+	/* Optional opaque PSA key holding the master secret (PSA_KEY_TYPE_DERIVE,
+	   HKDF-SHA-256, usage DERIVE). When set (!= PSA_KEY_ID_NULL) the raw
+	   master_secret bytes are ignored and all key derivation happens inside
+	   the secure domain. When PSA_KEY_ID_NULL (e.g. the EDHOC path), the
+	   master_secret bytes are imported into a temporary volatile derive key.
+	   Note: leaving this field unset in a designated initializer yields
+	   PSA_KEY_ID_NULL (0), preserving legacy/EDHOC behaviour. */
+	const psa_key_id_t master_secret_id;
+#endif
 	/*sender_id must be provided*/
 	const struct byte_array sender_id;
 	/*recipient_id must be provided*/

--- a/inc/oscore/oscore_cose.h
+++ b/inc/oscore/oscore_cose.h
@@ -15,19 +15,28 @@
 #include "common/byte_array.h"
 #include "common/oscore_edhoc_error.h"
 
+#ifdef OSCORE_PSA_OPAQUE_KEYS
+#include <psa/crypto.h>
+/* With opaque keys the Sender/Recipient keys are PSA handles, so the key is
+   passed by id and the AEAD runs without exposing key bytes to NS. */
+typedef psa_key_id_t oscore_key_t;
+#else
+typedef struct byte_array *oscore_key_t;
+#endif
+
 /**
  * @brief Decrypt the ciphertext
  * @param in_ciphertext: input ciphertext to be decrypted
  * @param out_plaintext: output plaintext
  * @param nonce the nonce
  * @param aad the aad
- * @param recipient_key the recipient key
+ * @param recipient_key the recipient key (PSA key id on MBEDTLS builds)
  * @return err
  */
 enum err oscore_cose_decrypt(struct byte_array *in_ciphertext,
 			     struct byte_array *out_plaintext,
 			     struct byte_array *nonce, struct byte_array *aad,
-			     struct byte_array *recipient_key);
+			     oscore_key_t recipient_key);
 
 /**
  * @brief Encrypt the plaintext
@@ -35,12 +44,12 @@ enum err oscore_cose_decrypt(struct byte_array *in_ciphertext,
  * @param out_ciphertext: output ciphertext with authentication tag (8 bytes)
  * @param nonce the nonce
  * @param sender_aad the aad
- * @param key the sender key
+ * @param key the sender key (PSA key id on MBEDTLS builds)
  * @return err
  */
 enum err oscore_cose_encrypt(struct byte_array *in_plaintext,
 			     struct byte_array *out_ciphertext,
 			     struct byte_array *nonce,
 			     struct byte_array *sender_aad,
-			     struct byte_array *key);
+			     oscore_key_t key);
 #endif

--- a/inc/oscore/security_context.h
+++ b/inc/oscore/security_context.h
@@ -20,6 +20,10 @@
 #include "common/byte_array.h"
 #include "common/oscore_edhoc_error.h"
 
+#ifdef OSCORE_PSA_OPAQUE_KEYS
+#include <psa/crypto.h>
+#endif
+
 /* Upper limit of SSN that is allowed by AEAD algorithm (AES-CCM-16-64-128) is 2^23-1, according to RFC 9053 p. 4.2.1.
    Exceeding this value results in constant 4.01 Unauthorized error, so new security context must be established.
    Note that this value is lower than MAX_PIV_FIELD_VALUE, which only defines maximum value that is writable to the SSN/PIV field.
@@ -49,7 +53,15 @@ enum echo_state {
 struct common_context {
 	enum AEAD_algorithm aead_alg;
 	enum hkdf kdf;
+#ifdef OSCORE_PSA_OPAQUE_KEYS
+	/* OSCORE master secret as an opaque PSA derive key; raw bytes never
+	   enter the non-secure domain. Set during oscore_context_init: either
+	   the caller's app-owned key or a temporary volatile key (then reset to
+	   PSA_KEY_ID_NULL once derivation is done). */
+	psa_key_id_t master_secret_id;
+#else
 	struct byte_array master_secret;
+#endif
 	struct byte_array master_salt; /*optional*/
 	struct byte_array id_context; /*optional*/
 	struct byte_array common_iv;
@@ -61,16 +73,26 @@ struct common_context {
 struct sender_context {
 	struct byte_array sender_id;
 	uint8_t sender_id_buf[7];
+#ifdef OSCORE_PSA_OPAQUE_KEYS
+	/* Derived Sender Key as a volatile PSA key handle (secure domain). */
+	psa_key_id_t sender_key_id;
+#else
 	struct byte_array sender_key;
 	uint8_t sender_key_buf[SENDER_KEY_LEN_];
+#endif
 	uint64_t ssn;
 };
 
 /* Recipient Context used to decrypt inbound messages */
 struct recipient_context {
 	struct byte_array recipient_id;
+#ifdef OSCORE_PSA_OPAQUE_KEYS
+	/* Derived Recipient Key as a volatile PSA key handle (secure domain). */
+	psa_key_id_t recipient_key_id;
+#else
 	struct byte_array recipient_key;
 	uint8_t recipient_key_buf[RECIPIENT_KEY_LEN_];
+#endif
 	uint8_t recipient_id_buf[RECIPIENT_ID_BUFF_LEN];
 	struct server_replay_window_t replay_window;
 	uint64_t notification_num;

--- a/src/common/crypto_wrapper.c
+++ b/src/common/crypto_wrapper.c
@@ -170,6 +170,43 @@ aead_mock_args_match_predefined(struct edhoc_mock_aead_in_out *predefined,
 }
 #endif // EDHOC_MOCK_CRYPTO_WRAPPER
 
+#ifdef MBEDTLS
+/* Core PSA AEAD operation shared by the byte-key path (aead) and the key-id
+   path (aead_with_key_id). Operates on an existing PSA key and does NOT import
+   or destroy it, so opaque/derived keys keep their bytes inside the secure
+   domain. psa_crypto_init() must have been called beforehand. */
+static enum err psa_aead_core(enum aes_operation op, psa_key_id_t key_id,
+			      const struct byte_array *in,
+			      struct byte_array *nonce,
+			      const struct byte_array *aad,
+			      struct byte_array *out, struct byte_array *tag)
+{
+	psa_algorithm_t alg =
+		PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, (uint32_t)tag->len);
+
+	if (op == DECRYPT) {
+		size_t out_len_re = 0;
+		TRY_EXPECT_PSA(psa_aead_decrypt(key_id, alg, nonce->ptr,
+						nonce->len, aad->ptr, aad->len,
+						in->ptr, in->len, out->ptr,
+						out->len, &out_len_re),
+			       PSA_SUCCESS, PSA_KEY_ID_NULL,
+			       unexpected_result_from_ext_lib);
+	} else {
+		size_t out_len_re;
+		TRY_EXPECT_PSA(psa_aead_encrypt(key_id, alg, nonce->ptr,
+						nonce->len, aad->ptr, aad->len,
+						in->ptr, in->len, out->ptr,
+						(size_t)(in->len + tag->len),
+						&out_len_re),
+			       PSA_SUCCESS, PSA_KEY_ID_NULL,
+			       unexpected_result_from_ext_lib);
+		memcpy(tag->ptr, out->ptr + out_len_re - tag->len, tag->len);
+	}
+	return ok;
+}
+#endif /* MBEDTLS */
+
 enum err WEAK aead(enum aes_operation op, const struct byte_array *in,
 		   const struct byte_array *key, struct byte_array *nonce,
 		   const struct byte_array *aad, struct byte_array *out,
@@ -230,28 +267,139 @@ enum err WEAK aead(enum aes_operation op, const struct byte_array *in,
 	TRY_EXPECT_PSA(psa_import_key(&attr, key->ptr, key->len, &key_id),
 		       PSA_SUCCESS, key_id, unexpected_result_from_ext_lib);
 
-	if (op == DECRYPT) {
-		size_t out_len_re = 0;
-		TRY_EXPECT_PSA(
-			psa_aead_decrypt(key_id, alg, nonce->ptr, nonce->len,
-					 aad->ptr, aad->len, in->ptr, in->len,
-					 out->ptr, out->len, &out_len_re),
-			PSA_SUCCESS, key_id, unexpected_result_from_ext_lib);
-	} else {
-		size_t out_len_re;
-		TRY_EXPECT_PSA(
-			psa_aead_encrypt(key_id, alg, nonce->ptr, nonce->len,
-					 aad->ptr, aad->len, in->ptr, in->len,
-					 out->ptr, (size_t)(in->len + tag->len),
-					 &out_len_re),
-			PSA_SUCCESS, key_id, unexpected_result_from_ext_lib);
-		memcpy(tag->ptr, out->ptr + out_len_re - tag->len, tag->len);
-	}
+	/* Run the operation on the freshly imported volatile key, then destroy
+	   it. This byte-key path is retained for EDHOC and TINYCRYPT; OSCORE
+	   uses the opaque key-id path (aead_with_key_id) instead. */
+	enum err core_result =
+		psa_aead_core(op, key_id, in, nonce, aad, out, tag);
 	TRY_EXPECT(psa_destroy_key(key_id), PSA_SUCCESS);
+	if (ok != core_result) {
+		return core_result;
+	}
 
 #endif
 	return ok;
 }
+
+#ifdef MBEDTLS
+enum err aead_with_key_id(enum aes_operation op, const struct byte_array *in,
+			  psa_key_id_t key_id, struct byte_array *nonce,
+			  const struct byte_array *aad, struct byte_array *out,
+			  struct byte_array *tag)
+{
+	TRY_EXPECT_PSA(psa_crypto_init(), PSA_SUCCESS, PSA_KEY_ID_NULL,
+		       unexpected_result_from_ext_lib);
+	return psa_aead_core(op, key_id, in, nonce, aad, out, tag);
+}
+
+enum err oscore_derive_aead_key(psa_key_id_t master_secret_id,
+				const struct byte_array *salt,
+				const struct byte_array *info, size_t bits,
+				psa_algorithm_t aead_alg,
+				psa_key_id_t *out_key_id)
+{
+	psa_status_t status;
+	psa_key_derivation_operation_t op = PSA_KEY_DERIVATION_OPERATION_INIT;
+	psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+
+	*out_key_id = PSA_KEY_ID_NULL;
+
+	TRY_EXPECT_PSA(psa_crypto_init(), PSA_SUCCESS, PSA_KEY_ID_NULL,
+		       unexpected_result_from_ext_lib);
+
+	status = psa_key_derivation_setup(&op, PSA_ALG_HKDF(PSA_ALG_SHA_256));
+	if (PSA_SUCCESS != status) {
+		goto err;
+	}
+	/* Empty salt is omitted; HKDF then uses a string of zeros per RFC 5869,
+	   matching the byte path in hkdf_extract(). */
+	if (salt && salt->ptr && salt->len) {
+		status = psa_key_derivation_input_bytes(
+			&op, PSA_KEY_DERIVATION_INPUT_SALT, salt->ptr,
+			salt->len);
+		if (PSA_SUCCESS != status) {
+			goto err;
+		}
+	}
+	status = psa_key_derivation_input_key(
+		&op, PSA_KEY_DERIVATION_INPUT_SECRET, master_secret_id);
+	if (PSA_SUCCESS != status) {
+		goto err;
+	}
+	status = psa_key_derivation_input_bytes(
+		&op, PSA_KEY_DERIVATION_INPUT_INFO, info->ptr, info->len);
+	if (PSA_SUCCESS != status) {
+		goto err;
+	}
+
+	psa_set_key_usage_flags(&attr,
+				PSA_KEY_USAGE_ENCRYPT | PSA_KEY_USAGE_DECRYPT);
+	psa_set_key_algorithm(&attr, aead_alg);
+	psa_set_key_type(&attr, PSA_KEY_TYPE_AES);
+	psa_set_key_bits(&attr, bits);
+	psa_set_key_lifetime(&attr, PSA_KEY_LIFETIME_VOLATILE);
+
+	status = psa_key_derivation_output_key(&attr, &op, out_key_id);
+	if (PSA_SUCCESS != status) {
+		goto err;
+	}
+
+	psa_key_derivation_abort(&op);
+	return ok;
+
+err:
+	psa_key_derivation_abort(&op);
+	handle_external_runtime_error((int)status, __FILE__, __LINE__);
+	return unexpected_result_from_ext_lib;
+}
+
+enum err oscore_derive_iv_bytes(psa_key_id_t master_secret_id,
+				const struct byte_array *salt,
+				const struct byte_array *info,
+				struct byte_array *out)
+{
+	psa_status_t status;
+	psa_key_derivation_operation_t op = PSA_KEY_DERIVATION_OPERATION_INIT;
+
+	TRY_EXPECT_PSA(psa_crypto_init(), PSA_SUCCESS, PSA_KEY_ID_NULL,
+		       unexpected_result_from_ext_lib);
+
+	status = psa_key_derivation_setup(&op, PSA_ALG_HKDF(PSA_ALG_SHA_256));
+	if (PSA_SUCCESS != status) {
+		goto err;
+	}
+	if (salt && salt->ptr && salt->len) {
+		status = psa_key_derivation_input_bytes(
+			&op, PSA_KEY_DERIVATION_INPUT_SALT, salt->ptr,
+			salt->len);
+		if (PSA_SUCCESS != status) {
+			goto err;
+		}
+	}
+	status = psa_key_derivation_input_key(
+		&op, PSA_KEY_DERIVATION_INPUT_SECRET, master_secret_id);
+	if (PSA_SUCCESS != status) {
+		goto err;
+	}
+	status = psa_key_derivation_input_bytes(
+		&op, PSA_KEY_DERIVATION_INPUT_INFO, info->ptr, info->len);
+	if (PSA_SUCCESS != status) {
+		goto err;
+	}
+	status = psa_key_derivation_output_bytes(&op, out->ptr, out->len);
+	if (PSA_SUCCESS != status) {
+		goto err;
+	}
+
+	psa_key_derivation_abort(&op);
+	return ok;
+
+err:
+	psa_key_derivation_abort(&op);
+	handle_external_runtime_error((int)status, __FILE__, __LINE__);
+	return unexpected_result_from_ext_lib;
+}
+#endif /* MBEDTLS */
 
 #ifdef EDHOC_MOCK_CRYPTO_WRAPPER
 static bool

--- a/src/oscore/coap2oscore.c
+++ b/src/oscore/coap2oscore.c
@@ -555,7 +555,11 @@ static enum err encrypt_wrapper(struct byte_array *plaintext,
 
 	/* Encrypt the plaintext */
 	TRY(oscore_cose_encrypt(plaintext, ciphertext, &nonce, &aad,
+#ifdef MBEDTLS
+				c->sc.sender_key_id));
+#else
 				&c->sc.sender_key));
+#endif
 
 	/* Update nonce only after successful encryption (for handling future responses). */
 	if (use_new_piv) {

--- a/src/oscore/oscore2coap.c
+++ b/src/oscore/oscore2coap.c
@@ -299,7 +299,11 @@ decrypt_wrapper(struct byte_array *ciphertext, struct byte_array *plaintext,
 
 	/* Decrypt the ciphertext */
 	TRY(oscore_cose_decrypt(ciphertext, plaintext, &nonce, &aad,
+#ifdef MBEDTLS
+				c->rc.recipient_key_id));
+#else
 				&c->rc.recipient_key));
+#endif
 
 	/* Update nonce only after successful decryption (for handling future responses) */
 	if (NULL != new_nonce_oscore_option) {

--- a/src/oscore/oscore_cose.c
+++ b/src/oscore/oscore_cose.c
@@ -62,7 +62,7 @@ enum err oscore_cose_decrypt(struct byte_array *in_ciphertext,
 			     struct byte_array *out_plaintext,
 			     struct byte_array *nonce,
 			     struct byte_array *recipient_aad,
-			     struct byte_array *key)
+			     oscore_key_t key)
 {
 	/* get enc_structure */
 	uint32_t aad_len = recipient_aad->len + ENCRYPT0_ENCODING_OVERHEAD;
@@ -74,8 +74,13 @@ enum err oscore_cose_decrypt(struct byte_array *in_ciphertext,
 
 	PRINT_ARRAY("Ciphertext", in_ciphertext->ptr, in_ciphertext->len);
 
+#ifdef MBEDTLS
+	TRY(aead_with_key_id(DECRYPT, in_ciphertext, key, nonce, &aad,
+			     out_plaintext, &tag));
+#else
 	TRY(aead(DECRYPT, in_ciphertext, key, nonce, &aad, out_plaintext,
 		 &tag));
+#endif
 
 	PRINT_ARRAY("Decrypted plaintext", out_plaintext->ptr,
 		    out_plaintext->len);
@@ -86,7 +91,7 @@ enum err oscore_cose_encrypt(struct byte_array *in_plaintext,
 			     struct byte_array *out_ciphertext,
 			     struct byte_array *nonce,
 			     struct byte_array *sender_aad,
-			     struct byte_array *key)
+			     oscore_key_t key)
 {
 	/* get enc_structure  */
 	uint32_t aad_len = sender_aad->len + ENCRYPT0_ENCODING_OVERHEAD;
@@ -99,8 +104,13 @@ enum err oscore_cose_encrypt(struct byte_array *in_plaintext,
 		BYTE_ARRAY_INIT(out_ciphertext->ptr + in_plaintext->len, 8);
 
 	out_ciphertext->len -= tag.len;
+#ifdef MBEDTLS
+	TRY(aead_with_key_id(ENCRYPT, in_plaintext, key, nonce, &aad,
+			     out_ciphertext, &tag));
+#else
 	TRY(aead(ENCRYPT, in_plaintext, key, nonce, &aad, out_ciphertext,
 		 &tag));
+#endif
 
 	PRINT_ARRAY("tag", tag.ptr, tag.len);
 	PRINT_ARRAY("Ciphertext", out_ciphertext->ptr, out_ciphertext->len);

--- a/src/oscore/security_context.c
+++ b/src/oscore/security_context.c
@@ -29,8 +29,85 @@
 #include "common/print_util.h"
 #include "common/unit_test.h"
 
+#ifdef MBEDTLS
+/* AEAD algorithm the derived Sender/Recipient keys may be used with. */
+#define OSCORE_PSA_AEAD_ALG                                                    \
+	PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, AUTH_TAG_LEN)
+
 /**
- * @brief       Common derive procedure used to derive the Common IV and 
+ * @brief       Builds the OSCORE HKDF info structure for a derivation.
+ * @param cc    pointer to the common context
+ * @param id    empty array for Common IV, sender / recipient ID for keys
+ * @param type  IV for Common IV, KEY for Sender / Recipient Keys
+ * @param info  out-array. Must be initialized
+ * @return      err
+ */
+static enum err build_hkdf_info(struct common_context *cc,
+				struct byte_array *id, enum derive_type type,
+				struct byte_array *info)
+{
+	if (cc->kdf != OSCORE_SHA_256) {
+		return oscore_unknown_hkdf;
+	}
+	TRY(oscore_create_hkdf_info(id, &cc->id_context, cc->aead_alg, type,
+				    info));
+	PRINT_ARRAY("info struct", info->ptr, info->len);
+	return ok;
+}
+
+/**
+ * @brief    Derives the Common IV (public, so kept as plain bytes).
+ */
+static enum err derive_common_iv(struct common_context *cc)
+{
+	BYTE_ARRAY_NEW(info, MAX_INFO_LEN, MAX_INFO_LEN);
+	TRY(build_hkdf_info(cc, &EMPTY_ARRAY, IV, &info));
+	TRY(oscore_derive_iv_bytes(cc->master_secret_id, &cc->master_salt,
+				   &info, &cc->common_iv));
+	PRINT_ARRAY("Common IV", cc->common_iv.ptr, cc->common_iv.len);
+	return ok;
+}
+
+/**
+ * @brief    Derives the Sender Key as an opaque volatile PSA key.
+ */
+static enum err derive_sender_key(struct common_context *cc,
+				  struct sender_context *sc)
+{
+	BYTE_ARRAY_NEW(info, MAX_INFO_LEN, MAX_INFO_LEN);
+	TRY(build_hkdf_info(cc, &sc->sender_id, KEY, &info));
+	/* Slot-leak guard: drop any handle from a previous derivation. Relies on
+	   the context being zero-initialized (PSA_KEY_ID_NULL) before first use. */
+	if (PSA_KEY_ID_NULL != sc->sender_key_id) {
+		psa_destroy_key(sc->sender_key_id);
+		sc->sender_key_id = PSA_KEY_ID_NULL;
+	}
+	TRY(oscore_derive_aead_key(cc->master_secret_id, &cc->master_salt,
+				   &info, PSA_BYTES_TO_BITS(SENDER_KEY_LEN_),
+				   OSCORE_PSA_AEAD_ALG, &sc->sender_key_id));
+	return ok;
+}
+
+/**
+ * @brief    Derives the Recipient Key as an opaque volatile PSA key.
+ */
+static enum err derive_recipient_key(struct common_context *cc,
+				     struct recipient_context *rc)
+{
+	BYTE_ARRAY_NEW(info, MAX_INFO_LEN, MAX_INFO_LEN);
+	TRY(build_hkdf_info(cc, &rc->recipient_id, KEY, &info));
+	if (PSA_KEY_ID_NULL != rc->recipient_key_id) {
+		psa_destroy_key(rc->recipient_key_id);
+		rc->recipient_key_id = PSA_KEY_ID_NULL;
+	}
+	TRY(oscore_derive_aead_key(cc->master_secret_id, &cc->master_salt,
+				   &info, PSA_BYTES_TO_BITS(RECIPIENT_KEY_LEN_),
+				   OSCORE_PSA_AEAD_ALG, &rc->recipient_key_id));
+	return ok;
+}
+#else /* !MBEDTLS */
+/**
+ * @brief       Common derive procedure used to derive the Common IV and
  *              Sender / Recipient Keys
  * @param cc    pointer to the common context
  * @param id    empty array for Common IV, sender / recipient ID for keys
@@ -60,7 +137,7 @@ STATIC enum err derive(struct common_context *cc, struct byte_array *id,
 }
 
 /**
- * @brief    Derives the Common IV 
+ * @brief    Derives the Common IV
  * @param    cc    pointer to the common context
  * @return   err
  */
@@ -72,7 +149,7 @@ static enum err derive_common_iv(struct common_context *cc)
 }
 
 /**
- * @brief    Derives the Sender Key 
+ * @brief    Derives the Sender Key
  * @param    cc    pointer to the common context
  * @param    sc    pointer to the sender context
  * @return   err
@@ -86,7 +163,7 @@ static enum err derive_sender_key(struct common_context *cc,
 }
 
 /**
- * @brief    Derives the Recipient Key 
+ * @brief    Derives the Recipient Key
  * @param    cc    pointer to the common context
  * @param    sc    pointer to the recipient context
  * @return   err
@@ -100,6 +177,7 @@ static enum err derive_recipient_key(struct common_context *cc,
 		    rc->recipient_key.len);
 	return ok;
 }
+#endif /* MBEDTLS */
 
 enum err oscore_context_init(struct oscore_init_params *params,
 			     struct context *c)
@@ -120,9 +198,37 @@ enum err oscore_context_init(struct oscore_init_params *params,
 	}
 
         c->cc.fresh_master_secret_salt = params->fresh_master_secret_salt;
-	c->cc.master_secret = params->master_secret;
 	c->cc.master_salt = params->master_salt;
 	c->cc.id_context = params->id_context;
+
+#ifdef MBEDTLS
+	/* Resolve the master secret to a PSA derive key. If the caller supplied
+	   an opaque handle, use it (the app owns its lifetime). Otherwise import
+	   the raw bytes into a temporary volatile derive key, used only for the
+	   derivations below and destroyed before returning (EDHOC / legacy
+	   callers). Either way the Sender/Recipient keys are produced as opaque
+	   PSA handles and the raw key bytes never persist in the context. */
+	bool owns_master_key = false;
+	psa_key_id_t master_secret_id = params->master_secret_id;
+
+	TRY_EXPECT(psa_crypto_init(), PSA_SUCCESS);
+	if (PSA_KEY_ID_NULL == master_secret_id) {
+		psa_key_attributes_t ms_attr = PSA_KEY_ATTRIBUTES_INIT;
+		psa_set_key_usage_flags(&ms_attr, PSA_KEY_USAGE_DERIVE);
+		psa_set_key_algorithm(&ms_attr, PSA_ALG_HKDF(PSA_ALG_SHA_256));
+		psa_set_key_type(&ms_attr, PSA_KEY_TYPE_DERIVE);
+		psa_set_key_lifetime(&ms_attr, PSA_KEY_LIFETIME_VOLATILE);
+		TRY_EXPECT(psa_import_key(&ms_attr, params->master_secret.ptr,
+					  params->master_secret.len,
+					  &master_secret_id),
+			   PSA_SUCCESS);
+		owns_master_key = true;
+	}
+	c->cc.master_secret_id = master_secret_id;
+#else
+	c->cc.master_secret = params->master_secret;
+#endif
+
 	c->cc.common_iv.len = sizeof(c->cc.common_iv_buf);
 	c->cc.common_iv.ptr = c->cc.common_iv_buf;
 	TRY(derive_common_iv(&c->cc));
@@ -134,20 +240,34 @@ enum err oscore_context_init(struct oscore_init_params *params,
 	c->rc.recipient_id.ptr = c->rc.recipient_id_buf;
 	memcpy(c->rc.recipient_id.ptr, params->recipient_id.ptr,
 	       params->recipient_id.len);
+#ifndef MBEDTLS
 	c->rc.recipient_key.len = sizeof(c->rc.recipient_key_buf);
 	c->rc.recipient_key.ptr = c->rc.recipient_key_buf;
+#endif
 	TRY(derive_recipient_key(&c->cc, &c->rc));
 
 	/*derive Sender Context************************************************/
 	c->sc.sender_id = params->sender_id;
+#ifndef MBEDTLS
 	c->sc.sender_key.len = sizeof(c->sc.sender_key_buf);
 	c->sc.sender_key.ptr = c->sc.sender_key_buf;
+#endif
 	struct nvm_key_t nvm_key = { .sender_id = c->sc.sender_id,
 				     .recipient_id = c->rc.recipient_id,
 				     .id_context = c->cc.id_context };
 
 	TRY(ssn_init(&nvm_key, &c->sc.ssn, params->fresh_master_secret_salt));
 	TRY(derive_sender_key(&c->cc, &c->sc));
+
+#ifdef MBEDTLS
+	/* The temporary master-secret key (if we created one) has served all
+	   derivations; destroy it so no derive key lingers. App-owned opaque
+	   keys are left untouched. */
+	if (owns_master_key) {
+		psa_destroy_key(master_secret_id);
+		c->cc.master_secret_id = PSA_KEY_ID_NULL;
+	}
+#endif
 
 	/*set up the request response context**********************************/
 	oscore_interactions_init(c->rrc.interactions);

--- a/test/oscore_integration_tests/oscore_integration_tests.c
+++ b/test/oscore_integration_tests/oscore_integration_tests.c
@@ -76,6 +76,10 @@ void t1_oscore_client_request_response(void)
 			(uint8_t *)&buf_oscore, &buf_oscore_len, &c_client);
 	zassert_equal(r, ok, "Error in coap2oscore!");
 
+#ifndef MBEDTLS
+	/* On MBEDTLS builds the Sender/Recipient keys are opaque PSA handles
+	   whose bytes cannot be read back; correctness is verified end-to-end
+	   by the encrypt/decrypt round-trip below. */
 	zassert_mem_equal__(c_client.sc.sender_key.ptr, T1__SENDER_KEY,
 			    c_client.sc.sender_key.len,
 			    "T1 sender key derivation failed");
@@ -83,6 +87,7 @@ void t1_oscore_client_request_response(void)
 	zassert_mem_equal__(c_client.rc.recipient_key.ptr, T1__RECIPIENT_KEY,
 			    c_client.rc.recipient_key.len,
 			    "T1 recipient key derivation failed");
+#endif
 
 	zassert_mem_equal__(c_client.cc.common_iv.ptr, T1__COMMON_IV,
 			    c_client.cc.common_iv.len,
@@ -282,6 +287,7 @@ void t4_oscore_server_key_derivation(void)
 
 	zassert_equal(r, ok, "Error in oscore_context_init");
 
+#ifndef MBEDTLS
 	zassert_mem_equal__(c_server.sc.sender_key.ptr, T4__SENDER_KEY,
 			    c_server.sc.sender_key.len,
 			    "T4 sender key derivation failed");
@@ -289,6 +295,7 @@ void t4_oscore_server_key_derivation(void)
 	zassert_mem_equal__(c_server.rc.recipient_key.ptr, T4__RECIPIENT_KEY,
 			    c_server.rc.recipient_key.len,
 			    "T4 recipient key derivation failed");
+#endif
 
 	zassert_mem_equal__(c_server.cc.common_iv.ptr, T4__COMMON_IV,
 			    c_server.cc.common_iv.len,
@@ -323,6 +330,7 @@ void t6_oscore_server_key_derivation(void)
 
 	zassert_equal(r, ok, "Error in oscore_context_init");
 
+#ifndef MBEDTLS
 	zassert_mem_equal__(c_server.sc.sender_key.ptr, T6__SENDER_KEY,
 			    c_server.sc.sender_key.len,
 			    "T6 sender key derivation failed");
@@ -330,6 +338,7 @@ void t6_oscore_server_key_derivation(void)
 	zassert_mem_equal__(c_server.rc.recipient_key.ptr, T6__RECIPIENT_KEY,
 			    c_server.rc.recipient_key.len,
 			    "T6 recipient key derivation failed");
+#endif
 
 	zassert_mem_equal__(c_server.cc.common_iv.ptr, T6__COMMON_IV,
 			    c_server.cc.common_iv.len,


### PR DESCRIPTION
This update introduces support for opaque PSA keys in the OSCORE implementation when built with MBEDTLS. Key changes include:

- Updated `oscore_init_params` to allow for a PSA key ID alongside the master secret.
- New functions for deriving AEAD keys and Common IV using PSA key derivation.
- Modifications to encryption and decryption functions to utilize PSA key IDs instead of raw keys.
- Adjustments in the security context to manage PSA key handles for sender and recipient keys.

These changes improve security by ensuring that key material does not leave the secure domain, aligning with modern cryptographic practices.